### PR TITLE
Change `init` command to `set`

### DIFF
--- a/Keeper.WindowsCredentialManager/Program.cs
+++ b/Keeper.WindowsCredentialManager/Program.cs
@@ -6,8 +6,8 @@ namespace WindowsCredentialManager
     {
         public static async Task<int> Main(string[] args)
         {
-            var initCommand = new Command(
-                name: "init",
+            var setCommand = new Command(
+                name: "set",
                 description: "Add a KSM Config to Windows Credential Manager."
             );
 
@@ -28,12 +28,12 @@ namespace WindowsCredentialManager
 
             var rootCommand = new RootCommand("KSM Windows Credential Manager");
 
-            rootCommand.AddCommand(initCommand);
+            rootCommand.AddCommand(setCommand);
             rootCommand.AddCommand(getCommand);
 
-            initCommand.AddArgument(appName);
-            initCommand.AddArgument(configArg);
-            initCommand.SetHandler((appName, configArg) =>
+            setCommand.AddArgument(appName);
+            setCommand.AddArgument(configArg);
+            setCommand.SetHandler((appName, configArg) =>
             {
                 CredentialManager.WriteCredential(appName, Environment.UserName, Parsing.ParseConfig(configArg));
                 // Exit with success code

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ As mentioned above, this utility is a self-contained executable file. Download t
 
 The executable supports two commands:
 
-1. `init`
+1. `set`
 2. `get`
 
 Both commands require an application `name` (i.e. the name of the credential in / to be stored in the Windows Credential Manager) as the first argument.
 
-### `init`
+### `set`
 
-`init` requires a second argument of the secret to be stored. This can be either a:
+`set` requires a second argument of the secret to be stored. This can be either a:
 
 1. BASE64 string
 2. JSON string
@@ -37,9 +37,9 @@ When the secret is saved to Windows Credential Manager it is first encoded into 
 
 ```shell
 # Save a secret
-binary_name init APPNAME eyJ1c2VybmFtZSI6ICJnb2xsdW0iLCAicGFzc3dvcmQiOiAiTXlQcmVjaW91cyJ9
+wcm set APPNAME eyJ1c2VybmFtZSI6ICJnb2xsdW0iLCAicGFzc3dvcmQiOiAiTXlQcmVjaW91cyJ9
 # or
-binary_name init APPNAME config.json
+wcm set APPNAME config.json
 
 # Retrieve a secret
 binary_name get APPNAME


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] You have read the contributing guide
- [x] Tests for the changes have been added
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

Saving a secret to the Windows Credential Manager currently uses the cli command `init`

## What is the new behavior?

- Saving a secret to the Windows Credential Manager now uses the cli command `set`-

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

## Other relevant information

N/A